### PR TITLE
Add python36 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@
 # This file will be regenerated if you run travis_pypi_setup.py
 
 language: python
-python: 3.5
+python: 3.6
 
 env:
+  - TOXENV=py36
   - TOXENV=py35
   - TOXENV=py34
   - TOXENV=py33

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # This file will be regenerated if you run travis_pypi_setup.py
 
 language: python
-python: 3.6
+python: 3.5
 
 env:
   - TOXENV=py36

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, flake8
+envlist = py27, ppy33, py34, py35, py36, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
Python 3.6 was officially released on Dec 23 2016.