### PR TITLE
Put examples into README because it is fairly small

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,42 @@ It currently supports ascii, latin-1, and utf-8 encodings.
 
 It supports "\\r", "\\r\\n", and "\\n" as new lines.
 
-Please see Usage section for examples.
+Usage Examples
+--------------
+
+An example of using `file_read_backwards` for `python2.7`::
+
+    #!/usr/bin/env python2.7
+
+    from file_read_backwards import FileReadBackwards
+
+    f = FileReadBackwards("/tmp/file", encoding="utf-8")
+
+    # getting lines by lines starting from the last line up
+    for l in f:
+        print l
+
+    # do it again
+    for l in f:
+        print l
+
+
+Another example using `python3.3`::
+
+    #!/usr/bin/env python3.3
+
+    from file_read_backwards import FileReadBackwards
+
+    f = FileReadBackwards("/tmp/file", encoding="utf-8")
+
+    # getting lines by lines starting from the last line up
+    for l in f:
+        print(l)
+
+    # do it again
+    for l in f:
+        print(l)
+
 
 Credits
 ---------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,35 +2,4 @@
 Usage
 =====
 
-An example of using `file_read_backwards` for `python2.7`::
-
-    #!/usr/bin/env python2.7
-
-    from file_read_backwards import FileReadBackwards
-
-    f = FileReadBackwards("/tmp/file", encoding="utf-8")
-
-    # getting lines by lines starting from the last line up
-    for l in f:
-        print l
-
-    # do it again
-    for l in f:
-        print l
-
-
-Another example using `python3.3`::
-
-    #!/usr/bin/env python3.3
-
-    from file_read_backwards import FileReadBackwards
-
-    f = FileReadBackwards("/tmp/file", encoding="utf-8")
-
-    # getting lines by lines starting from the last line up
-    for l in f:
-        print(l)
-
-    # do it again
-    for l in f:
-        print(l)
+Please see :doc:`readme`.


### PR DESCRIPTION
Just so that we have less clicking around, all information we need are on README.
Put a link to README from the original usage section.
