### PR TITLE
Fix "Explicitly number replacement fields in a format string" issue

### DIFF
--- a/file_read_backwards/file_read_backwards.py
+++ b/file_read_backwards/file_read_backwards.py
@@ -22,8 +22,8 @@ class FileReadBackwards:
             chunk_size (int): How many bytes to read at a time
         """
         if encoding not in supported_encodings:
-            error_message = "{} encoding was not supported/tested.".format(encoding)
-            error_message += "Supported encodings are '{}'".format(",".join(supported_encodings))
+            error_message = "{0} encoding was not supported/tested.".format(encoding)
+            error_message += "Supported encodings are '{0}'".format(",".join(supported_encodings))
             raise NotImplementedError(error_message)
 
         self.path = path

--- a/tests/test_buffer_work_space.py
+++ b/tests/test_buffer_work_space.py
@@ -48,7 +48,7 @@ class TestFindFurthestNewLine(unittest.TestCase):
             test_string = base_string + n
             expected_value = len(test_string) - 1
             r = _find_furthest_new_line(test_string)
-            self.assertEqual(r, expected_value, msg="Test with {} as new line".format(repr(n)))
+            self.assertEqual(r, expected_value, msg="Test with {0} as new line".format(repr(n)))
 
     def test_find_furthest_new_line_with_bytestring_with_new_line_in_the_middle(self):
         """Expect return value pointing to the middle of the test string where the newline is at."""
@@ -57,7 +57,7 @@ class TestFindFurthestNewLine(unittest.TestCase):
             test_string = base_string + n + base_string
             expected_value = len(base_string) + len(n) - 1
             r = _find_furthest_new_line(test_string)
-            self.assertEqual(r, expected_value, msg="Test with {} as new line".format(repr(n)))
+            self.assertEqual(r, expected_value, msg="Test with {0} as new line".format(repr(n)))
 
     def test_find_furthest_new_line_with_bytestring_with_new_line_in_the_middle_and_end(self):
         """Expect return value of the last index of the test_string because the new line is at the end."""
@@ -66,7 +66,7 @@ class TestFindFurthestNewLine(unittest.TestCase):
             test_string = base_string + n + base_string + n
             expected_value = len(test_string) - 1
             r = _find_furthest_new_line(test_string)
-            self.assertEqual(r, expected_value, msg="Test with {} as new line".format(repr(n)))
+            self.assertEqual(r, expected_value, msg="Test with {0} as new line".format(repr(n)))
 
 
 class TestRemoveTrailingNewLine(unittest.TestCase):
@@ -96,7 +96,7 @@ class TestRemoveTrailingNewLine(unittest.TestCase):
             self.assertEqual(
                 r,
                 expected_string,
-                msg="Test with {} followed by {} as new line at the end of str".format(repr(expected_string), repr(n)))
+                msg="Test with {0} followed by {1} as new line at the end of str".format(repr(expected_string), repr(n)))
 
     def test_remove_trailing_new_line_with_non_empty_byte_string_with_variety_of_new_lines_in_the_middle(self):
         """Expect nothing to change because the new line is in the middle."""
@@ -105,7 +105,7 @@ class TestRemoveTrailingNewLine(unittest.TestCase):
             test_string = base_string + n + base_string
             expected_string = test_string
             r = _remove_trailing_new_line(test_string)
-            self.assertEqual(r, expected_string, msg="Test with {} as new line".format(repr(n)))
+            self.assertEqual(r, expected_string, msg="Test with {0} as new line".format(repr(n)))
 
 
 class TestGetFileSize(unittest.TestCase):

--- a/tests/test_file_read_backwards.py
+++ b/tests/test_file_read_backwards.py
@@ -54,7 +54,7 @@ class TestFileReadBackwards(unittest.TestCase):
             self.assertEqual(
                 expected_lines,
                 lines_read,
-                msg="Test with {} encoding with {} as newline".format(encoding, repr(new_line)))
+                msg="Test with {0} encoding with {1} as newline".format(encoding, repr(new_line)))
             os.unlink(t.name)
 
     def test_file_with_one_line_of_text_with_accented_char_followed_by_a_new_line(self):
@@ -70,14 +70,14 @@ class TestFileReadBackwards(unittest.TestCase):
             lines_read = deque()
             for l in f:
                 lines_read.appendleft(s)
-            self.assertEqual(expected_lines, lines_read, msg="Test with {} as newline".format(repr(new_line)))
+            self.assertEqual(expected_lines, lines_read, msg="Test with {0} as newline".format(repr(new_line)))
             os.unlink(t.name)
 
     def test_file_with_one_line_of_text_followed_by_a_new_line_with_different_encodings(self):
         """Test a file with just one line of text followed by a new line."""
         for encoding, new_line in itertools.product(supported_encodings, new_lines):
             with tempfile.NamedTemporaryFile(delete=False) as t:
-                TestFileReadBackwards.write(t, "something{}".format(new_line), encoding)
+                TestFileReadBackwards.write(t, "something{0}".format(new_line), encoding)
             f = FileReadBackwards(t.name)
             expected_lines = deque(["something"])
             lines_read = deque()
@@ -86,7 +86,7 @@ class TestFileReadBackwards(unittest.TestCase):
             self.assertEqual(
                 expected_lines,
                 lines_read,
-                msg="Test with {} encoding with {} as newline".format(encoding, repr(new_line)))
+                msg="Test with {0} encoding with {1} as newline".format(encoding, repr(new_line)))
             os.unlink(t.name)
 
     def test_file_with_varying_number_of_new_lines_and_some_text_in_chunk_size(self):
@@ -109,7 +109,7 @@ class TestFileReadBackwards(unittest.TestCase):
                 self.assertEqual(
                     expected_lines,
                     lines_read,
-                    msg="Test with {} of new line {} followed by {} of {}".format(number_of_new_lines, repr(new_line),
+                    msg="Test with {0} of new line {1} followed by {2} of {3}".format(number_of_new_lines, repr(new_line),
                                                                                   chunk_size, repr(s)))
                 os.unlink(t.name)
 
@@ -134,7 +134,7 @@ class TestFileReadBackwards(unittest.TestCase):
                 self.assertEqual(
                     expected_lines,
                     lines_read,
-                    msg="Test with {} of new line {} followed by {} of \\xc3\\xa9".format(number_of_new_lines,
+                    msg="Test with {0} of new line {1} followed by {2} of \\xc3\\xa9".format(number_of_new_lines,
                                                                                           repr(new_line), chunk_size))
                 os.unlink(t.name)
 

--- a/travis_pypi_setup.py
+++ b/travis_pypi_setup.py
@@ -60,7 +60,7 @@ def fetch_public_key(repo):
     keyurl = 'https://api.travis-ci.org/repos/{0}/key'.format(repo)
     data = json.loads(urlopen(keyurl).read().decode())
     if 'key' not in data:
-        errmsg = "Could not find public key for repo: {}.\n".format(repo)
+        errmsg = "Could not find public key for repo: {0}.\n".format(repo)
         errmsg += "Have you already added your GitHub repo to Travis?"
         raise ValueError(errmsg)
     return data['key']


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Explicitly number replacement fields in a format string](https://www.quantifiedcode.com/app/issue_class/3aSZNLMu)
Issue details: [https://www.quantifiedcode.com/app/project/gh:robin81:file_read_backwards?groups=code_patterns/%3A3aSZNLMu](https://www.quantifiedcode.com/app/project/gh:robin81:file_read_backwards?groups=code_patterns/%3A3aSZNLMu)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)