### PR TITLE
Changing Authors layout

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,13 +2,6 @@
 Credits
 =======
 
-Development Lead
-----------------
-
 * Robin Robin <robin81@gmail.com>
 * John Leslie <johnaleslie@gmail.com>
-
-Contributors
-------------
-
 * Samuel Giffard <mulugruntz@gmail.com>


### PR DESCRIPTION
I disagree with the default `cookiecutter` template that has different sections for `Authors`.
