### PR TITLE
Release 1.2.2: re-release 121

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -33,3 +33,9 @@ History
 ------------------
 
 * Made doc strings consistent to Google style and some code linting
+
+
+1.2.2 (2017-11-19)
+------------------
+
+* Re-release of 1.2.1 for ease of updating pypi page for updated travis & pyup.

--- a/file_read_backwards/__init__.py
+++ b/file_read_backwards/__init__.py
@@ -4,4 +4,4 @@ from .file_read_backwards import FileReadBackwards  # noqa: F401
 
 __author__ = """Robin Robin"""
 __email__ = 'robinsquare42@gmail.com'
-__version__ = '1.2.1'
+__version__ = '1.2.2'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.1
+current_version = 1.2.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ test_requirements = [
 
 setup(
     name='file_read_backwards',
-    version='1.2.1',
+    version='1.2.2',
     description="Memory efficient way of reading files line-by-line from the end of file",
     long_description=readme + '\n\n' + history,
     author="Robin Robin",


### PR DESCRIPTION
Re-release of 1.2.1 as 1.2.2 for ease of updating pypi information, specifically:

1. pyup's link
1. travis' link