### PR TITLE
chore: drop python 3.3 for support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 python:
   - "pypy"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,7 +101,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check
+3. The pull request should work for Python 2.6, 2.7, 3.4 and 3.5, and for PyPy. Check
    https://travis-ci.org/robin81/file_read_backwards/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ An example of using `file_read_backwards` for `python2.7`::
         for l in frb:
             print l
 
-Another example using `python3.3`::
+Another example using `python3.4`::
 
     from file_read_backwards import FileReadBackwards
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, flake8
+envlist = py27, py34, py35, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
Python 3.3 has reached EOL, per
https://www.python.org/downloads/release/python-337/