### PR TITLE
chore: update dependencies in requirements to be latest

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,8 +3,8 @@ bumpversion==0.5.3
 wheel==0.31.1
 watchdog==0.8.3
 flake8==3.5.0
-tox==3.0.0
+tox==3.2.1
 Sphinx==1.7.6
 coverage==4.5.1
-cryptography==2.2.2
+cryptography==2.3.1
 PyYAML==3.13


### PR DESCRIPTION
cryptography 2.3.1 is needed to resolve security issues.

Per 2.3.1 change log, https://cryptography.io/en/latest/changelog/#v2-3,
:meth:`~cryptography.hazmat.primitives.ciphers.AEADDecryptionContext.finalize_with_tag`
allowed tag truncation by default which can allow tag forgery in some cases.
The method now enforces the ``min_tag_length`` provided to the
:class:`~cryptography.hazmat.primitives.ciphers.modes.GCM` constructor.