### PR TITLE
fix: respond to CVE-2017-18342

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,4 @@ Sphinx==1.8.2
 tox==3.6.1
 coverage==4.5.1
 cryptography==2.4.2
-PyYAML==3.13
+PyYAML==4.2b1


### PR DESCRIPTION
CVE-2017-18342 (https://nvd.nist.gov/vuln/detail/CVE-2017-18342)

high severity
Vulnerable versions: < 4.2b1
Patched version: 4.2b1
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code.
In other words, yaml.safe_load is not used.