### PR TITLE
chore: ignore pyup updates for packages that will break python 3.7

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,9 @@
 bumpversion==0.6.0
 coverage==7.2.2
 cryptography==40.0.1
-flake8==5.0.4
+flake8==5.0.4  # pyup: ignore, latest version does not with python 3.7
 PyYAML==6.0
-Sphinx==4.3.2
-tox==3.28.0
+Sphinx==4.3.2  # pyup: ignore, latest version does not work with python 3.7
+tox==3.28.0  # pyup: ignore, latest version does not work with python 3.7
 watchdog==3.0.0
 wheel==0.40.0


### PR DESCRIPTION
To allow devs to develop on pure python 3.7 environment, ignore packages (used for development purposes) are not supported in python 3.7.

An alternative is to suggest devs to work only in python 3.11, even though the library itself can be used in python 3.7-3.11.

We will consider the alternatives if there are compelling reasons to use newer versions of those packages during development process.