### PR TITLE
chore: readthedocs.org will require this configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+---
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
readthedocs.org will start requiring this configuration file starting July 24 2023.

Reference:
[blog post](https://blog.readthedocs.com/migrate-configuration-v2/)