### PR TITLE
chore: continue to build for python3.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # 22.04 has python 3.7, see https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]


### PR DESCRIPTION
Continue to build python 3.7 for now.
