### PR TITLE
update coverage

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 bumpversion==0.6.0
-coverage==7.2.7
+coverage==7.6.9
 cryptography==42.0.7
 flake8==5.0.4  # pyup: ignore, latest version does not with python 3.7
 PyYAML==6.0.1


### PR DESCRIPTION
- feat: support python 3.13
- chore: Bump version: 3.1.0 → 3.2.0
- Update coverage from 7.2.7 to 7.6.9
