### PR TITLE
This PR updates [cryptography](https://pypi.org/project/cryptography) from **42.0.7** to **44.0.0**.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 bumpversion==0.6.0
 coverage==7.6.9
-cryptography==42.0.7
+cryptography==44.0.0
 flake8==5.0.4  # pyup: ignore, latest version does not with python 3.7
 PyYAML==6.0.1
 pytest==7.4.0


### PR DESCRIPTION
See [change log](https://cryptography.io/en/latest/changelog/#v44-0-2).
